### PR TITLE
Add newly shipped "security" property

### DIFF
--- a/data/processed/envs.json
+++ b/data/processed/envs.json
@@ -3,67 +3,78 @@
     "name": "nodejs",
     "version": "0.2.0",
     "date": "2011-08-26",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "0.3.0",
     "date": "2011-08-26",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "0.4.0",
     "date": "2011-08-26",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "0.5.0",
     "date": "2011-08-26",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "0.6.0",
     "date": "2011-11-04",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "0.7.0",
     "date": "2012-01-17",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "0.8.0",
     "date": "2012-06-22",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "0.9.0",
     "date": "2012-07-20",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "0.10.0",
     "date": "2013-03-11",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "0.11.0",
     "date": "2013-03-28",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "0.12.0",
     "date": "2015-02-06",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "iojs",
@@ -149,744 +160,868 @@
     "name": "nodejs",
     "version": "4.0.0",
     "date": "2015-09-08",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "4.1.0",
     "date": "2015-09-17",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "4.2.0",
     "date": "2015-10-12",
-    "lts": "Argon"
+    "lts": "Argon",
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "4.3.0",
     "date": "2016-02-09",
-    "lts": "Argon"
+    "lts": "Argon",
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "4.4.0",
     "date": "2016-03-08",
-    "lts": "Argon"
+    "lts": "Argon",
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "4.5.0",
     "date": "2016-08-16",
-    "lts": "Argon"
+    "lts": "Argon",
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "4.6.0",
     "date": "2016-09-27",
-    "lts": "Argon"
+    "lts": "Argon",
+    "security": true
   },
   {
     "name": "nodejs",
     "version": "4.7.0",
     "date": "2016-12-06",
-    "lts": "Argon"
+    "lts": "Argon",
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "4.8.0",
     "date": "2017-02-21",
-    "lts": "Argon"
+    "lts": "Argon",
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "4.9.0",
     "date": "2018-03-28",
-    "lts": "Argon"
+    "lts": "Argon",
+    "security": true
   },
   {
     "name": "nodejs",
     "version": "5.0.0",
     "date": "2015-10-29",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "5.1.0",
     "date": "2015-11-17",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "5.2.0",
     "date": "2015-12-09",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "5.3.0",
     "date": "2015-12-15",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "5.4.0",
     "date": "2016-01-06",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "5.5.0",
     "date": "2016-01-21",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "5.6.0",
     "date": "2016-02-09",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "5.7.0",
     "date": "2016-02-23",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "5.8.0",
     "date": "2016-03-09",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "5.9.0",
     "date": "2016-03-16",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "5.10.0",
     "date": "2016-04-01",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "5.11.0",
     "date": "2016-04-21",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "5.12.0",
     "date": "2016-06-23",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "6.0.0",
     "date": "2016-04-26",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "6.1.0",
     "date": "2016-05-05",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "6.2.0",
     "date": "2016-05-17",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "6.3.0",
     "date": "2016-07-06",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "6.4.0",
     "date": "2016-08-12",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "6.5.0",
     "date": "2016-08-26",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "6.6.0",
     "date": "2016-09-14",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "6.7.0",
     "date": "2016-09-27",
-    "lts": false
+    "lts": false,
+    "security": true
   },
   {
     "name": "nodejs",
     "version": "6.8.0",
     "date": "2016-10-12",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "6.9.0",
     "date": "2016-10-18",
-    "lts": "Boron"
+    "lts": "Boron",
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "6.10.0",
     "date": "2017-02-21",
-    "lts": "Boron"
+    "lts": "Boron",
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "6.11.0",
     "date": "2017-06-06",
-    "lts": "Boron"
+    "lts": "Boron",
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "6.12.0",
     "date": "2017-11-06",
-    "lts": "Boron"
+    "lts": "Boron",
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "6.13.0",
     "date": "2018-02-10",
-    "lts": "Boron"
+    "lts": "Boron",
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "6.14.0",
     "date": "2018-03-28",
-    "lts": "Boron"
+    "lts": "Boron",
+    "security": true
   },
   {
     "name": "nodejs",
     "version": "6.15.0",
     "date": "2018-11-27",
-    "lts": "Boron"
+    "lts": "Boron",
+    "security": true
   },
   {
     "name": "nodejs",
     "version": "6.16.0",
     "date": "2018-12-26",
-    "lts": "Boron"
+    "lts": "Boron",
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "6.17.0",
     "date": "2019-02-28",
-    "lts": "Boron"
+    "lts": "Boron",
+    "security": true
   },
   {
     "name": "nodejs",
     "version": "7.0.0",
     "date": "2016-10-25",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "7.1.0",
     "date": "2016-11-08",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "7.2.0",
     "date": "2016-11-22",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "7.3.0",
     "date": "2016-12-20",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "7.4.0",
     "date": "2017-01-04",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "7.5.0",
     "date": "2017-01-31",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "7.6.0",
     "date": "2017-02-21",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "7.7.0",
     "date": "2017-02-28",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "7.8.0",
     "date": "2017-03-29",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "7.9.0",
     "date": "2017-04-11",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "7.10.0",
     "date": "2017-05-02",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "8.0.0",
     "date": "2017-05-30",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "8.1.0",
     "date": "2017-06-08",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "8.2.0",
     "date": "2017-07-19",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "8.3.0",
     "date": "2017-08-08",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "8.4.0",
     "date": "2017-08-15",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "8.5.0",
     "date": "2017-09-12",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "8.6.0",
     "date": "2017-09-26",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "8.7.0",
     "date": "2017-10-11",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "8.8.0",
     "date": "2017-10-24",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "8.9.0",
     "date": "2017-10-31",
-    "lts": "Carbon"
+    "lts": "Carbon",
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "8.10.0",
     "date": "2018-03-06",
-    "lts": "Carbon"
+    "lts": "Carbon",
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "8.11.0",
     "date": "2018-03-28",
-    "lts": "Carbon"
+    "lts": "Carbon",
+    "security": true
   },
   {
     "name": "nodejs",
     "version": "8.12.0",
     "date": "2018-09-10",
-    "lts": "Carbon"
+    "lts": "Carbon",
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "8.13.0",
     "date": "2018-11-20",
-    "lts": "Carbon"
+    "lts": "Carbon",
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "8.14.0",
     "date": "2018-11-27",
-    "lts": "Carbon"
+    "lts": "Carbon",
+    "security": true
   },
   {
     "name": "nodejs",
     "version": "8.15.0",
     "date": "2018-12-26",
-    "lts": "Carbon"
+    "lts": "Carbon",
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "8.16.0",
     "date": "2019-04-16",
-    "lts": "Carbon"
+    "lts": "Carbon",
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "9.0.0",
     "date": "2017-10-31",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "9.1.0",
     "date": "2017-11-07",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "9.2.0",
     "date": "2017-11-14",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "9.3.0",
     "date": "2017-12-12",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "9.4.0",
     "date": "2018-01-10",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "9.5.0",
     "date": "2018-01-31",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "9.6.0",
     "date": "2018-02-21",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "9.7.0",
     "date": "2018-03-01",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "9.8.0",
     "date": "2018-03-07",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "9.9.0",
     "date": "2018-03-21",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "9.10.0",
     "date": "2018-03-28",
-    "lts": false
+    "lts": false,
+    "security": true
   },
   {
     "name": "nodejs",
     "version": "9.11.0",
     "date": "2018-04-04",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "10.0.0",
     "date": "2018-04-24",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "10.1.0",
     "date": "2018-05-08",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "10.2.0",
     "date": "2018-05-23",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "10.3.0",
     "date": "2018-05-29",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "10.4.0",
     "date": "2018-06-06",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "10.5.0",
     "date": "2018-06-20",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "10.6.0",
     "date": "2018-07-04",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "10.7.0",
     "date": "2018-07-18",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "10.8.0",
     "date": "2018-08-01",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "10.9.0",
     "date": "2018-08-15",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "10.10.0",
     "date": "2018-09-06",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "10.11.0",
     "date": "2018-09-19",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "10.12.0",
     "date": "2018-10-10",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "10.13.0",
     "date": "2018-10-30",
-    "lts": "Dubnium"
+    "lts": "Dubnium",
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "10.14.0",
     "date": "2018-11-27",
-    "lts": "Dubnium"
+    "lts": "Dubnium",
+    "security": true
   },
   {
     "name": "nodejs",
     "version": "10.15.0",
     "date": "2018-12-26",
-    "lts": "Dubnium"
+    "lts": "Dubnium",
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "10.16.0",
     "date": "2019-05-28",
-    "lts": "Dubnium"
+    "lts": "Dubnium",
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "11.0.0",
     "date": "2018-10-23",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "11.1.0",
     "date": "2018-10-30",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "11.2.0",
     "date": "2018-11-15",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "11.3.0",
     "date": "2018-11-27",
-    "lts": false
+    "lts": false,
+    "security": true
   },
   {
     "name": "nodejs",
     "version": "11.4.0",
     "date": "2018-12-07",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "11.5.0",
     "date": "2018-12-18",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "11.6.0",
     "date": "2018-12-26",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "11.7.0",
     "date": "2019-01-17",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "11.8.0",
     "date": "2019-01-24",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "11.9.0",
     "date": "2019-01-30",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "11.10.0",
     "date": "2019-02-14",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "11.11.0",
     "date": "2019-03-05",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "11.12.0",
     "date": "2019-03-14",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "11.13.0",
     "date": "2019-03-28",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "11.14.0",
     "date": "2019-04-10",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "11.15.0",
     "date": "2019-04-30",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "12.0.0",
     "date": "2019-04-23",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "12.1.0",
     "date": "2019-04-29",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "12.2.0",
     "date": "2019-05-07",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "12.3.0",
     "date": "2019-05-21",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "12.4.0",
     "date": "2019-06-04",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "12.5.0",
     "date": "2019-06-26",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "12.6.0",
     "date": "2019-07-03",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "12.7.0",
     "date": "2019-07-23",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "12.8.0",
     "date": "2019-08-06",
-    "lts": false
+    "lts": false,
+    "security": false
   },
   {
     "name": "nodejs",
     "version": "12.9.0",
     "date": "2019-08-20",
-    "lts": false
+    "lts": false,
+    "security": false
   }
 ]

--- a/scripts/process.js
+++ b/scripts/process.js
@@ -15,7 +15,8 @@ var processedData = fs.readdirSync(path.join(__dirname, '../data/raw')).reduce(f
         name: envName,
         version: env.version.substr(1),
         date: env.date,
-        lts: env.lts
+        lts: env.lts,
+        security: env.security
       };
     }));
 }, []).sort(function (a, b) {


### PR DESCRIPTION
This PR adds the `security` property to processed data (already exists in raw data as of https://github.com/nodejs/nodejs-dist-indexer/pull/9).

This is super useful for understanding the minimum secure version of Node.js, which is a valuable data point that we have so far lacked within the ecosystem.