### PR TITLE
chore: Move semver to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
     "semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   ],
   "author": "Sergey Rubanov <chi187@gmail.com>",
   "license": "MIT",
-  "dependencies": {
+  "dependencies": {},
+  "devDependencies": {
     "semver": "^6.3.0"
   }
 }


### PR DESCRIPTION
The module is just used by the process.js script, which is used to build the json files. Therefore it shouldn't be needed by projects depending on this package